### PR TITLE
Add Intel XPU support for inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ response = processor.decode(output_ids[0], skip_special_tokens=True)
 print(response)
 ```
 
+> **Note**: RynnBrain also runs on Intel XPU (integrated and discrete GPUs) via PyTorch's native XPU backend — simply replace `"cuda"` with `"xpu"` in the two `.to(...)` calls above. No other code changes are required. Verified on RynnBrain-4B (Qwen3-VL-4B-Instruct base): CPU vs XPU logits MSE = 2.9e-07, greedy-decoded output identical.
+
 
 
 ### Inference with SGLang

--- a/demo.py
+++ b/demo.py
@@ -11,12 +11,18 @@ FPS = 2
 MAX_FRAMES = 512
 MODEL_PATH = ""
 
+if torch.xpu.is_available():
+    DEVICE = "xpu:0"
+elif torch.cuda.is_available():
+    DEVICE = "cuda:0"
+else:
+    DEVICE = "cpu"
 
 model = AutoModelForImageTextToText.from_pretrained(
     MODEL_PATH,
     torch_dtype=torch.bfloat16,
-    device_map={"": "cuda:0"},
-    attn_implementation="flash_attention_2",
+    device_map={"": DEVICE},
+    attn_implementation="sdpa",
 )
 
 processor = AutoProcessor.from_pretrained(MODEL_PATH)

--- a/planning/server.py
+++ b/planning/server.py
@@ -39,8 +39,11 @@ def unload_all_models():
     
     loaded_models.clear()
     gc.collect()
-    
-    if TORCH_AVAILABLE and torch.cuda.is_available():
+
+    if TORCH_AVAILABLE and torch.xpu.is_available():
+        logging.info("Cleaning up XPU cache...")
+        torch.xpu.empty_cache()
+    elif TORCH_AVAILABLE and torch.cuda.is_available():
         logging.info("Cleaning up CUDA cache...")
         torch.cuda.empty_cache()
     


### PR DESCRIPTION
### What This PR do

Add Intel XPU support for inference

- **README.md**: added a note in the Quick Start section pointing out that '.to("cuda")' can be replaced with '.to("xpu")' with no other changes
- **demo.py**: was hard-blocked on non-CUDA hardware (device_map={"": "cuda:0"} and attn_implementation="flash_attention_2", which requires the CUDA-only flash-attn package). Now auto-detects xpu/cuda/cpu and uses "sdpa" (the model's own tested-working default attention implementation)
- **planning/server.py**: added XPU branch to the CUDA-only memory cleanup helper

Verified end-to-end on RynnBrain-4B (Qwen3-VL-4B-Instruct base) on Intel Graphics [0xe211]:
- README quickstart example ran unmodified except .to("xpu"), produced a correct bounding-box response
- Logits MSE (CPU vs XPU, float32): 2.86e-07
- Argmax token match rate: 100.00%
- Greedy-decoded text (bf16, CPU vs XPU): identical